### PR TITLE
Add support for custom intiface setups (ws(s)://ip:port)

### DIFF
--- a/myclasses.py
+++ b/myclasses.py
@@ -8,7 +8,9 @@ maindefault = {
     "OSCBListenIP": "127.0.0.1", "OSCBListenPort": 9001,
     "OSCSendIP": "127.0.0.1", "OSCSendPort": 9000,
     "OSCProcess": False,
-    "OSCtoButtplug": True
+    "OSCtoButtplug": True,
+    "IntifaceProtocol": "ws",
+    "IntifaceIP": "127.0.0.1", "IntifacePort": 12345
 }
 
 

--- a/osc_d10/osc/osc_server_manager.py
+++ b/osc_d10/osc/osc_server_manager.py
@@ -14,6 +14,9 @@ class OSCServerManager:
         self.server_port = main_configuration["OSCBListenPort"]
         self.client_ip = main_configuration["OSCSendIP"]
         self.client_port = main_configuration["OSCSendPort"]
+        self.intiface_protocol = main_configuration["IntifaceProtocol"]
+        self.intiface_ip = main_configuration["IntifaceIP"]
+        self.intiface_port = main_configuration["IntifacePort"]
         self.dispatcher = osc_dispatcher_d10.D10Dispatcher()
         self.client = udp_client.SimpleUDPClient(self.client_ip, self.client_port)
         self.mapped_commands = 0

--- a/osc_d10/osc_buttplug/osc_buttplug.py
+++ b/osc_d10/osc_buttplug/osc_buttplug.py
@@ -268,7 +268,7 @@ async def connected_client(bp_manager: OSCButtplugManager) -> ButtplugClient:
             client.device_added_handler += device_added
             client.device_removed_handler += device_removed
             """Try to connect to the server"""
-            print_buttplug("Trying to  connect to  Interface server")
+            print_buttplug(f"Trying to  connect to  Interface server {ws}")
             await client.connect(connector)
             print_buttplug("Could connect to  Interface server")
             return client
@@ -309,7 +309,7 @@ async def run_osc_buttplug(osc_manager: OSCServerManager) -> None:
     try:
         que_buttplug: janus.Queue[Any] = janus.Queue(20)
         # manager object that will keep track of the configuration and some usefull objects
-        bp_manager = osc_d10.osc_buttplug.osc_buttplug_manager.OSCButtplugManager(que_buttplug)
+        bp_manager = osc_d10.osc_buttplug.osc_buttplug_manager.OSCButtplugManager(que_buttplug, osc_manager)
         # pass the syncronous version for the dipatcher, runs blocking code.
         osc_buttplug_setup.run_initial_setup(osc_manager, bp_manager)
     except Exception as e:

--- a/osc_d10/osc_buttplug/osc_buttplug_manager.py
+++ b/osc_d10/osc_buttplug/osc_buttplug_manager.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 import janus
+from osc_d10.osc.osc_server_manager import OSCServerManager
 
 
 class BpDevCommand(Enum):
@@ -21,10 +22,20 @@ class BpDevCommandInterface(Enum):
 
 class OSCButtplugManager:
     """Class to store and access buttplug data"""
-    def __init__(self, queue: janus.Queue):
+    def __init__(self, queue: janus.Queue,  config: OSCServerManager):
         # buttplug client parameters
         self.client_name = "OSC_D10"
-        self.web_sockets = "ws://127.0.0.1:12345"
+
+        self.web_sockets = "{protocol}://{ip}:{port}"
+        if config.intiface_protocol == "":
+            self.web_sockets = self.web_sockets.replace("{protocol}://", "")
+
+        if config.intiface_port == "":
+            self.web_sockets = self.web_sockets.replace(":{port}", "")
+
+        self.web_sockets = self.web_sockets.format(protocol = config.intiface_protocol,
+                                                   ip = config.intiface_ip,
+                                                   port = config.intiface_port)
         # queue
         self.queue = queue
 


### PR DESCRIPTION
Adds `IntifaceProtocol`, `IntifaceIP` and `IntifacePort` to configuration json.

Now prints which server is being connected to.

Use case examples:
- Port already in use by another service.
- Intiface running on a computer that is seperate to the one currently running the OSC_D10 server.
- Connections to domains in the style of wss://subdomain.domain.tld (no explicit port).
